### PR TITLE
hotfix/prevent-to-close-modal-on-backdrop-click

### DIFF
--- a/client/app/retrospective/retrospective.controller.js
+++ b/client/app/retrospective/retrospective.controller.js
@@ -16,7 +16,7 @@ angular.module('pokerestimateApp')
     }else{
       //open modal to ask for username and type when user joins
       $scope.userType = "player"; //default option in modal
-      var modalInstance = $modal.open({templateUrl: modalPath + 'username.html', keyboard:false, scope: this});
+      var modalInstance = $modal.open({templateUrl: modalPath + 'username.html', keyboard:false, backdrop: 'static', scope: this});
       modalInstance.result.then(function (data) {
         $scope.currentUser = {username: data.username, type: data.userType};
         socket.emit('joinSession', {roomId: $scope.sessionId, username: data.username, type: data.userType, sessionType: 'retrospective'});


### PR DESCRIPTION
When a user click out side the modal to join the session, this is closed and she is able to click on REVEL button, in order to avoid this I added the backdrop property.

backdrop functionallity according to the angular-foundation's documentation:

```
controls presence of a backdrop. Allowed values:

* true default
* false: no backdrop
* static': backdrop is present but modal window is not closed when clicking outside of the modal window.
```