### PR TITLE
 hotfix/prevent-to-update-empty-entry-on-retrospective

### DIFF
--- a/client/app/templates/modals/editEntry.jade
+++ b/client/app/templates/modals/editEntry.jade
@@ -1,4 +1,4 @@
 div.entry-modal
  textarea(ng-model="currentEntry.text")
  button.button.showy(ng-click='$dismiss(this)') Cancel
- button.button.showy(ng-click='$close(this)') OK
+ button.button.showy.disabled(ng-click='$close(this)' ng-disabled="!currentEntry.text") OK

--- a/e2e/retrospective/retrospective.spec.js
+++ b/e2e/retrospective/retrospective.spec.js
@@ -128,6 +128,18 @@ describe('Retrospective View', function() {
     expect(page.impList.first().getText()).toBe('it will be much better next time!');
   });
 
+  it('sn\'t able to edit entries if is empty',function(){
+    page.addGoodBtn.click();
+    page.newGoodEntry.sendKeys('awesome!');
+    browser.actions().sendKeys(protractor.Key.ENTER).perform();
+    page.goodEdit.click();
+    page.editEntry.clear();
+    page.okBtn.click();
+    browser.sleep(1000);
+
+    expect(page.modal.isPresent()).toBe(true);
+  });
+
   it('s able to cancel edit entries', function() {
     page.addGoodBtn.click();
     page.newGoodEntry.sendKeys('awesome!');

--- a/e2e/retrospective/retrospective.spec.js
+++ b/e2e/retrospective/retrospective.spec.js
@@ -128,7 +128,7 @@ describe('Retrospective View', function() {
     expect(page.impList.first().getText()).toBe('it will be much better next time!');
   });
 
-  it('sn\'t able to edit entries if is empty',function(){
+  it('sn\'t able to edit an entry if it is empty',function(){
     page.addGoodBtn.click();
     page.newGoodEntry.sendKeys('awesome!');
     browser.actions().sendKeys(protractor.Key.ENTER).perform();


### PR DESCRIPTION
When a user create a new entry and tries to update it, if the input is empty and she clicks on "Ok" button the Entry will be updated without text, I added the proper code to avoid this.